### PR TITLE
Fix shebang lines for improved Linux compatibility

### DIFF
--- a/mini-moul.sh
+++ b/mini-moul.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 source ~/mini-moulinette/mini-moul/config.sh
 
 function handle_sigint {

--- a/mini-moul/config.sh
+++ b/mini-moul/config.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 #constants
 readonly GREEN='\033[38;5;84m'
 readonly RED='\033[38;5;197m'

--- a/mini-moul/test.sh
+++ b/mini-moul/test.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 source config.sh
 
 #utils


### PR DESCRIPTION
This pull request addresses an issue where the provided shell scripts (.sh files) were not running on Linux but functioned on macOS. The fix involves adding the shebang line #!/bin/bash to the beginning of all three ".sh" files:

- mini-moul.sh
- mini-moul/test.sh
- mini-moul/config.sh

Adding the shebang line specifies the Bash interpreter, ensuring consistent behavior across Linux systems. This enhances the portability and compatibility of the scripts.