### PR TITLE
Add invalid base tests to C07/ex04 (ft_convert_base)

### DIFF
--- a/mini-moul/tests/C07/ex04/ft_convert_base.c
+++ b/mini-moul/tests/C07/ex04/ft_convert_base.c
@@ -53,7 +53,6 @@ int main(void)
             .base_to = "5",
             .expected = NULL,
         },
-	*/
     };
     int count = sizeof(tests) / sizeof(tests[0]);
 

--- a/mini-moul/tests/C07/ex04/ft_convert_base.c
+++ b/mini-moul/tests/C07/ex04/ft_convert_base.c
@@ -39,11 +39,10 @@ int main(void)
             .base_to = "0123456789ABCDEF",
             .expected = "2A",
         },
-	/*
         {
             .desc = "Invalid base_from",
             .nbr = "42",
-            .base_from = "012345678",
+            .base_from = "01234567899",
             .base_to = "01",
             .expected = NULL,
         },
@@ -51,7 +50,7 @@ int main(void)
             .desc = "Invalid base_to",
             .nbr = "42",
             .base_from = "0123456789",
-            .base_to = "01a",
+            .base_to = "5",
             .expected = NULL,
         },
 	*/


### PR DESCRIPTION
A base with duplicate characters is considered invalid, so is a base with less than 2 characters