### PR TITLE
Add ft_convert_base2 if exists in c07/ex04 - ft_convert_base

### DIFF
--- a/mini-moul/tests/C07/ex04/ft_convert_base.c
+++ b/mini-moul/tests/C07/ex04/ft_convert_base.c
@@ -2,6 +2,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include "../../../../ex04/ft_convert_base.c"
+#if __has_include("../../../../ex04/ft_convert_base2.c")
+# include "../../../../ex04/ft_convert_base2.c"
+#endif
 #include "../../../utils/constants.h"
 
 typedef struct s_test


### PR DESCRIPTION
The exercise c07 ex04 provides the possibility to have a second file with the name `ft_convert_base2.c`, mini moulinette should accept it.

> Turn-in directory : ex04/
Files to turn in : ft_convert_base.c, ft_convert_base2.c
Allowed functions : malloc, free