### PR TITLE
Handle edge case in C02/ex02

### DIFF
--- a/mini-moul/tests/C02/ex02/ft_str_is_alpha.c
+++ b/mini-moul/tests/C02/ex02/ft_str_is_alpha.c
@@ -23,14 +23,14 @@ int	test2(void)
 {
 	int result;
 
-	result = ft_str_is_alpha("abcdefghijk2l");
+	result = ft_str_is_alpha("abcghij[`aBCZ");
 	if (result != 0)
 	{
-		printf("    " RED "[2] ft_str_is_alpha(\"abcdefghijk2l\") Expected 0, got %d\n", result);
+		printf("    " RED "[2] ft_str_is_alpha(\"abcghij[`aBCZ\") Expected 0, got %d\n", result);
 		return (-1);
 	}
 	else
-		printf("  "GREEN CHECKMARK GREY" [2] ft_str_is_alpha(\"abcdefghijk2l\") Expected 0, got %d\n"DEFAULT, result);
+		printf("  "GREEN CHECKMARK GREY" [2] ft_str_is_alpha(\"abcghij[`aBCZ\") Expected 0, got %d\n"DEFAULT, result);
 	return (0);
 }
 


### PR DESCRIPTION
The tests did not check if the characters between 'Z' and 'a' where handeled as not an alpha char

Dec Hex	Oct	Char
91	5B	133	[
92	5C	134	\
93	5D	135	]
94	5E	136	^
95	5F	137	_
96	60	140	`