### PR TITLE
add: Added test case for C03/ex04/ft_strstr.c

### DIFF
--- a/mini-moul/tests/C03/ex04/ft_strstr.c
+++ b/mini-moul/tests/C03/ex04/ft_strstr.c
@@ -47,6 +47,12 @@ int main(void)
             .find = "abcd",
             .expected_output = NULL,
         },
+        {
+            .desc = "Find a substring with existing characters",
+            .str = "-62,47 +62,47",
+            .find = "-47",
+            .expected_output = NULL,
+        },
     };
     int count = sizeof(tests) / sizeof(tests[0]);
 


### PR DESCRIPTION
The tests in C03/ex04/ft_strstr.c did not check the case in where the to_find string contained characters in the str string exactly as they are searched.